### PR TITLE
upgrade from aws-sdk to aws-sdk-ruby

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -3,7 +3,7 @@ set -eEu
 set -o pipefail
 
 cat > ci/vars <<EOF
-declare -rx VERSION="3.0.1"
+declare -rx VERSION="1.79.0"
 
 BUILD_DATE="$(date +%Y%m%dT%H%M)"
 declare -rx BUILD_DATE

--- a/ci/help.bats
+++ b/ci/help.bats
@@ -1,0 +1,4 @@
+@test "help displays correctly" {
+  run docker-compose run --rm downer --help
+  [[ ${output} =~ Usage:\ shutdown ]]
+}

--- a/ci/version.bats
+++ b/ci/version.bats
@@ -1,4 +1,4 @@
-@test "aws-sdk is the expected version" {
-  run docker-compose run --rm --entrypoint gem downer list '^aws-sdk$'
+@test "aws-sdk-ec2 is the expected version" {
+  run docker-compose run --rm --entrypoint gem downer list '^aws-sdk-ec2$'
   [[ ${output} =~ \(${VERSION}\) ]]
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - all
     pids_limit: 20
     cpu_shares: 512
-    mem_limit: 32M
+    mem_limit: 64M
     shm_size: 16M
 
   downer_tag:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -12,7 +12,7 @@ RUN apk upgrade --update && \
         && \
     rm -f /var/cache/apk/* && \
     gem install -N \
-        "aws-sdk:=${VERSION}" \
+        "aws-sdk-ec2:=${VERSION}" \
         json_pure \
         memoist2 \
         && \


### PR DESCRIPTION
aws-sdk-ruby supercedes aws-sdk.

This commit pins to aws-sdk-ec2, which
* requires aws-sdk-ruby and
* avoids extra resource-specific aws-sdk gems.